### PR TITLE
Fixed "TypeError columns.split is not a function"

### DIFF
--- a/lib/DynamoDbExportCsv.js
+++ b/lib/DynamoDbExportCsv.js
@@ -66,7 +66,8 @@ function DynamoDBExportCSV(awsAccessKeyId, awsSecretAccessKey, awsRegion) {
     // is represented
     function getItemWithHeaders(item, columns) {
         var row = {};
-        _.each(columns.split(','), function (column) {
+        columns = Array.isArray(columns) ? columns : columns.split(',');
+        _.each(columns, function (column) {
             if (item[column]) {
                 row[column] = item[column].S || item[column].N || item[column].BOOL;
             }


### PR DESCRIPTION
Added a conditional check to detect if "columns" is already an array, then there's no needs to split it into an array again.